### PR TITLE
fix bug: Smart Quotes option in storyboard not working

### DIFF
--- a/SmartPush/PushViewController.m
+++ b/SmartPush/PushViewController.m
@@ -24,6 +24,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    self.payload.automaticQuoteSubstitutionEnabled = NO;
     self.payload.string = @"{\"aps\":{\"alert\":\"This is some fancy message.\",\"badge\":6,\"sound\": \"default\"}}";
      
     //    [[ NSUserDefaults  standardUserDefaults] removeObjectForKey:KEY_CERNAME];


### PR DESCRIPTION
The double quotation marks will change from half-width to full-width during the input process before the modification.

https://user-images.githubusercontent.com/5902224/227093354-821f8169-d263-4a1c-8550-452a601dcbdc.mov

