### PR TITLE
fix log显示未上一次选中的证书

### DIFF
--- a/SmartPush/PushViewController.m
+++ b/SmartPush/PushViewController.m
@@ -49,10 +49,10 @@
             [self applyWithCerPath:url];
         }];
     }else{
-        [self log:[NSString stringWithFormat:@"选择证书 %@",_cerName] warning:NO];
         [self resetConnect];
         _currentSec =   [_certificates objectAtIndex:sender.indexOfSelectedItem-2];
         _cerName = _currentSec.name;
+        [self log:[NSString stringWithFormat:@"选择证书 %@", _cerName] warning:NO];
         [self connect:nil];
         
     }


### PR DESCRIPTION
问题：使用过过程中发现，选中的证书在输入信息框中，显示的都是上次的证书名
解决方案：
把log放到_currentSec和_cerName赋值的后面即可