### PR TITLE
修复 选中的证书和实际使用的证书不一致

### DIFF
--- a/SmartPush/PushViewController.m
+++ b/SmartPush/PushViewController.m
@@ -96,7 +96,7 @@
     int selectIndex= -1;
     for (int i=0;i<[_certificates count];i++) {
         Sec *sec =  [_certificates objectAtIndex:i];
-        [self.cerPopUpButton addItemWithTitle:[NSString stringWithFormat:@"%@ %@ %@", sec.name, sec.expire,[sec.key isEqualToString:@"lastSelected"]?@"文件":@""]];
+        [self.cerPopUpButton addItemWithTitle:[NSString stringWithFormat:@"%d. %@ %@ %@", i+1,sec.name, sec.expire,[sec.key isEqualToString:@"lastSelected"]?@"文件":@""]];
         //        [suffix appendString:@" "];
         if([_cerName length]>0 && [sec.name isEqualToString:_cerName])
         {


### PR DESCRIPTION
当钥匙串中存在多个相同证书时，_certificates数组为实际证书数，但是addItemWithTitle: 添加相同的title会进行去重，出现UI展示少于_certificates数组元素个数的情况。进而导致选中UI时的索引与_certificates中对应的证书不一致。